### PR TITLE
Lisää ainakin Ubuntu 13.10:n kannalta mahdollisen virheen korjauksen

### DIFF
--- a/web/viikko1.md
+++ b/web/viikko1.md
@@ -254,6 +254,13 @@ Avaa konsoli antamalla komentoriviltä (sovelluksen sisältävästä hakemistost
 
     rails console
 
+Jos konsoli antaa virheilmoituksen, johon sisältyy teksti "cannot load such file -- readline (LoadError), niin ainakin Ubuntu 13.10 -ympäristössä tämä korjataan asentamalla libreadline-dev ja kääntämällä ruby uudelleen
+
+    apt-get install libreadline-dev
+
+    rbenv install 2.0.0-p353
+
+
 Tee kaikki seuraavat komennot myös itse:
 
 ```ruby


### PR DESCRIPTION
Ubuntu 13.10 -ympäristössä jää ohjeill rails käännettäessä pois yksi tarpeellinen kirjasto, jota ilman ei railsin consoli toimi. Oheinen lisäys olisi hyvä laittaa myös wikiin.
